### PR TITLE
Use HTTPS url for meritbadge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-brotli-decompressor
 
-[![crates.io](http://meritbadge.herokuapp.com/brotli-decompressor)](https://crates.io/crates/brotli)
+[![crates.io](https://meritbadge.herokuapp.com/brotli-decompressor)](https://crates.io/crates/brotli)
 [![Build Status](https://travis-ci.org/dropbox/rust-brotli-decompressor.svg?branch=master)](https://travis-ci.org/dropbox/rust-brotli-decompressor)
 
 ## What's new in version 2.1.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-brotli-decompressor
 
-[![crates.io](https://meritbadge.herokuapp.com/brotli-decompressor)](https://crates.io/crates/brotli)
+[![crates.io](https://meritbadge.herokuapp.com/brotli-decompressor)](https://crates.io/crates/brotli-decompressor)
 [![Build Status](https://travis-ci.org/dropbox/rust-brotli-decompressor.svg?branch=master)](https://travis-ci.org/dropbox/rust-brotli-decompressor)
 
 ## What's new in version 2.1.2


### PR DESCRIPTION
Right now this readme file uses an HTTP url to reference a meritbadge image, which ends up producing "broken/degraded https" browser UI on the crates.io page https://crates.io/crates/brotli-decompressor.

This patch just upgrades this to an HTTPS url (which still works), to avoid that problem. (Literally a 1-character change, changing "http" to "https" in https://meritbadge.herokuapp.com/brotli-decompressor )