### PR TITLE
Export decode::BrotliDecoderIsFinished and BrotliDecoderTakeOutput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub use io_wrappers::{IntoIoReader, IoReaderWrapper, IntoIoWriter, IoWriterWrapp
 //                               mut total_out: &mut usize,
 //                               mut s: &mut BrotliState<AllocU8, AllocU32, AllocHC>);
 
-pub use decode::{BrotliDecompressStream, BrotliResult, BrotliDecoderHasMoreOutput, BrotliDecoderIsFinished};
+pub use decode::{BrotliDecompressStream, BrotliResult, BrotliDecoderHasMoreOutput, BrotliDecoderIsFinished, BrotliDecoderTakeOutput};
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub use io_wrappers::{IntoIoReader, IoReaderWrapper, IntoIoWriter, IoWriterWrapp
 //                               mut total_out: &mut usize,
 //                               mut s: &mut BrotliState<AllocU8, AllocU32, AllocHC>);
 
-pub use decode::{BrotliDecompressStream, BrotliResult, BrotliDecoderHasMoreOutput};
+pub use decode::{BrotliDecompressStream, BrotliResult, BrotliDecoderHasMoreOutput, BrotliDecoderIsFinished};
 
 
 


### PR DESCRIPTION
subj, this function is missing for these who uses low level API (non-C variant)