### PR TITLE
Don't apply #[no_mangle] pointlessly

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -31,7 +31,6 @@ use ::dictionary::{kBrotliDictionary, kBrotliDictionaryOffsetsByLength,
                    kBrotliMinDictionaryWordLength};
 pub use huffman::{HuffmanCode, HuffmanTreeGroup};
 #[repr(C)]
-#[no_mangle]
 #[derive(Debug)]
 pub enum BrotliResult {
   ResultSuccess = 1,

--- a/src/ffi/interface.rs
+++ b/src/ffi/interface.rs
@@ -5,7 +5,6 @@ pub enum c_void{
     _Nothing = 0,
 }
 
-#[no_mangle]
 #[repr(C)]
 #[allow(dead_code)]
 pub enum BrotliDecoderParameter {
@@ -15,7 +14,6 @@ pub enum BrotliDecoderParameter {
 
 
 #[repr(C)]
-#[no_mangle]
 pub enum BrotliDecoderResult {
     BROTLI_DECODER_RESULT_ERROR = 0,
     BROTLI_DECODER_RESULT_SUCCESS = 1,
@@ -34,15 +32,12 @@ impl From<BrotliResult> for BrotliDecoderResult {
     }
   }
 }
-#[no_mangle]
 pub type brotli_alloc_func = Option<extern "C" fn(data: *mut c_void, size: usize) -> *mut c_void>;
 
-#[no_mangle]
 pub type brotli_free_func = Option<extern "C" fn(data: *mut c_void, ptr: *mut c_void) -> ()>;
 
 
 #[repr(C)]
-#[no_mangle]
 #[derive(Clone)]
 pub struct CAllocator {
     pub alloc_func: brotli_alloc_func,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,6 +1,5 @@
 #![cfg(not(feature="safe"))]
 
-#[no_mangle]
 #[cfg(feature="std")]
 use std::{thread,panic, io, boxed, any, string};
 #[cfg(feature="std")]
@@ -39,7 +38,6 @@ type BrotliAdditionalErrorData = boxed::Box<any::Any + Send + 'static>;
 type BrotliAdditionalErrorData = ();
 
 #[repr(C)]
-#[no_mangle]
 pub struct BrotliDecoderState {
     pub custom_allocator: CAllocator,
     pub decompressor: ::BrotliState<SubclassableAllocator,

--- a/src/huffman/mod.rs
+++ b/src/huffman/mod.rs
@@ -26,7 +26,6 @@ pub const BROTLI_HUFFMAN_MAX_TABLE_SIZE: u32 = 1080;
 pub const BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH: u32 = 5;
 
 #[repr(C)]
-#[no_mangle]
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct HuffmanCode {
   pub value: u16, // symbol value or table offset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,6 @@ pub fn copy_from_to<R: io::Read, W: io::Write>(mut r: R, mut w: W) -> io::Result
   Ok(out_size)
 }
 
-#[no_mangle]
 #[repr(C)]
 pub struct BrotliDecoderReturnInfo {
     pub decoded_size: usize,

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,6 @@ pub enum WhichTreeGroup {
 }
 #[repr(C)]
 #[derive(Clone,Copy, Debug)]
-#[no_mangle]
 pub enum BrotliDecoderErrorCode{
   BROTLI_DECODER_NO_ERROR = 0,
   /* Same as BrotliDecoderResult values */


### PR DESCRIPTION
It doesn't make sense to apply `#[no_mangle]` to `struct`s/`enum`s/type aliases, since the names of those items are not mangled, or even directly included in compiled binaries. This was only accepted by `rustc` accidentally, and newer versions of the compilers warn about this:
```
warning: attribute should be applied to a function or static
 --> src/ffi/mod.rs:3:1
  |
3 | #[no_mangle]
  | ^^^^^^^^^^^^
4 | #[cfg(feature="std")]
5 | use std::{thread,panic, io, boxed, any, string};
  | ------------------------------------------------ not a function or static
  |
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
```
Furthermore, this [can even cause compiler bugs in the latest nightly](https://github.com/rust-lang/rust/issues/86261).