### PR TITLE
Feature gate FFI to avoid polluting externs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brotli-decompressor"
-version = "2.5.0"
+version = "3.0.0"
 authors = ["Daniel Reiter Horn <danielrh@dropbox.com>", "The Brotli Authors"]
 description = "A brotli decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. Alternatively, --features=unsafe turns off array bounds checks and memory initialization but provides a safe interface for the caller.  Without adding the --features=unsafe argument, all included code is safe. For compression in addition to this library, download https://github.com/dropbox/rust-brotli "
 license = "BSD-3-Clause/MIT"
@@ -26,9 +26,10 @@ lto=true
 
 [features]
 seccomp = []
-default=["std"]
+default=["std", "ffi-api"]
 std = ["alloc-stdlib"]
 unsafe = ["alloc-no-stdlib/unsafe", "alloc-stdlib/unsafe"]
 pass-through-ffi-panics = []
 disable-timer = []
 benchmark = []
+ffi-api = []

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(feature="safe"))]
-
 #[cfg(feature="std")]
 use std::{thread,panic, io, boxed, any, string};
 #[cfg(feature="std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod reader;
 pub mod writer;
 pub use huffman::{HuffmanCode, HuffmanTreeGroup};
 pub use state::BrotliState;
+#[cfg(feature="ffi-api")]
 pub mod ffi;
 pub use reader::{DecompressorCustomIo};
 


### PR DESCRIPTION
Similar to https://github.com/dropbox/rust-brotli/pull/48 the externs should be feature gated. It appears they might've been intended to be gated behind "safe", but no such feature exists ("unsafe" exists but it seems better to separate these).

I've also bumped the crate version to 3.0.0 because the main brotli library would stop exporting FFI functions otherwise. After this is merged I'll make a PR to the main brotli library to bump this crate's version and have its FFI feature depend on this crate's FFI feature.