### PR TITLE
Support cargo-fuzz

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "brotli-decompressor-fuzz"
+version = "0.0.0"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.brotli-decompressor]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "decompress_into_vec"
+path = "fuzz_targets/decompress_into_vec.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "decompress_into_fixed"
+path = "fuzz_targets/decompress_into_fixed.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decompress_into_fixed.rs
+++ b/fuzz/fuzz_targets/decompress_into_fixed.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+extern crate libfuzzer_sys;
+
+use std::io::Cursor;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut input = Cursor::new(data);
+    let mut output_buf = [0u8; 2048];
+    let mut output = Cursor::new(&mut output_buf[..]);
+    let _ = brotli_decompressor::BrotliDecompress(&mut input, &mut output);
+});

--- a/fuzz/fuzz_targets/decompress_into_vec.rs
+++ b/fuzz/fuzz_targets/decompress_into_vec.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+extern crate libfuzzer_sys;
+
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    let mut input = Cursor::new(data);
+    let mut output = Cursor::new(Vec::new());
+    let _ = brotli_decompressor::BrotliDecompress(&mut input, &mut output);
+});


### PR DESCRIPTION
Two targets to start with:

1) decompression into a growable writer,
2) decompression into a fixed-size buffer,

The latter finds https://github.com/dropbox/rust-brotli/issues/213 quite quickly.