### PR TITLE
Loosen the version bound on alloc-no-stdlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental=false
 lto=true
 
 [dependencies]
-"alloc-no-stdlib" = {version="~2.0"}
+"alloc-no-stdlib" = {version="2.0"}
 "alloc-stdlib" = {version="~0.2", optional=true}
 
 [features]


### PR DESCRIPTION
There is no obvious reason to pin this to 2.0.x. Perhaps it was an accident. In any case, let’s trust in SemVer.

Fixes:

```
WARNING: Dependency on alloc-no-stdlib stricter than necessary: ~2.0
```