### PR TITLE
writer flushes when it cannot write anymore

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -216,6 +216,7 @@ pub struct DecompressorWriterCustomIo<ErrType,
 pub fn write_all<ErrType, W: CustomWrite<ErrType>>(writer: &mut W, mut buf : &[u8]) -> Result<(), ErrType> {
     while buf.len() != 0 {
           match writer.write(buf) {
+                Ok(0) => return writer.flush(),
                 Ok(bytes_written) => buf = &buf[bytes_written..],
                 Err(e) => return Err(e),
           }


### PR DESCRIPTION
like when Cursor is full

Fixes infinite loop in 
```rust
use std::io::Cursor;
use std::io::Write;

fn main() {
    let buf = Cursor::new(Box::new([0u8; 0x1000]) as Box<[u8]>);
    let mut w = brotli::DecompressorWriter::new(buf, 0x1000);
    let v1 = vec![0xb, 0xff, 0x45, 0x45, 0x45, 0x45, 0x45, 0xa, 0xcc, 0x0, 0x10, 0x45, 0x45, 0x65, 0x7a, 0x45, 0x45, 0x45, 0x0, 0x6, 0xca, 0xb1, 0xef,
        0x3b, 0xbe, 0x52, 0xb, 0x8, 0xb, 0x0, 0xa, 0x0, 0xa, 0xb, 0xff, 0x45, 0x45, 0x45, 0x45, 0x45, 0xa,0xcc, 0x0, 0x10, 0x45, 0x45, 0x65, 0x7a, 0x45, 0x45, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x45, 0x0,
        0x6, 0xca, 0x53, 0x45, 0x48, 0x7e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x7f,
    ];
    println!("start");
    let r = w.write(&v1);
    println!("Ok, 0xworld! {:?}", r);
}
```


with Cargo.toml
```toml
[package]
name = "brolol"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
brotli = "~8.0.1"
```

Found by oss-fuzz on suricata