### PR TITLE
Inline some functions to improve perf by 10-30%

### DIFF
--- a/src/bit_reader/mod.rs
+++ b/src/bit_reader/mod.rs
@@ -257,6 +257,7 @@ pub fn BrotliGet16BitsUnmasked(br: &mut BrotliBitReader, input: &[u8]) -> u32 {
 }
 
 // Returns the specified number of bits from br without advancing bit pos.
+#[inline(always)]
 pub fn BrotliGetBits(br: &mut BrotliBitReader, n_bits: u32, input: &[u8]) -> u32 {
   BrotliFillBitWindow(br, n_bits, input);
   (BrotliGetBitsUnmasked(br) as u32) & BitMask(n_bits)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -456,6 +456,7 @@ fn SafeReadSymbol(table: &[HuffmanCode],
 }
 
 // Makes a look-up in first level Huffman table. Peeks 8 bits.
+#[inline(always)]
 fn PreloadSymbol(safe: bool,
                  table: &[HuffmanCode],
                  br: &mut bit_reader::BrotliBitReader,
@@ -473,6 +474,7 @@ fn PreloadSymbol(safe: bool,
 
 // Decodes the next Huffman code using data prepared by PreloadSymbol.
 // Reads 0 - 15 bits. Also peeks 8 following bits.
+#[inline(always)]
 fn ReadPreloadedSymbol(table: &[HuffmanCode],
                        br: &mut bit_reader::BrotliBitReader,
                        bits: &mut u32,
@@ -1947,6 +1949,7 @@ pub fn SafeReadBits(br: &mut bit_reader::BrotliBitReader,
 }
 
 // Precondition: s.distance_code < 0
+#[inline(always)]
 pub fn ReadDistanceInternal<AllocU8: alloc::Allocator<u8>,
                             AllocU32: alloc::Allocator<u32>,
                             AllocHC: alloc::Allocator<HuffmanCode>>
@@ -2014,7 +2017,7 @@ pub fn ReadDistanceInternal<AllocU8: alloc::Allocator<u8>,
   true
 }
 
-
+#[inline(always)]
 pub fn ReadCommandInternal<AllocU8: alloc::Allocator<u8>,
                            AllocU32: alloc::Allocator<u32>,
                            AllocHC: alloc::Allocator<HuffmanCode>>
@@ -2073,10 +2076,12 @@ pub fn ReadCommandInternal<AllocU8: alloc::Allocator<u8>,
 }
 
 
+#[inline(always)]
 fn WarmupBitReader(safe: bool, br: &mut bit_reader::BrotliBitReader, input: &[u8]) -> bool {
   safe || bit_reader::BrotliWarmupBitReader(br, input)
 }
 
+#[inline(always)]
 fn CheckInputAmount(safe: bool, br: &bit_reader::BrotliBitReader, num: u32) -> bool {
   safe || bit_reader::BrotliCheckInputAmount(br, num)
 }
@@ -2107,11 +2112,9 @@ fn memmove16(data: &mut [u8], u32off_dst: u32, u32off_src: u32) {
   let mut local_array: [u8; 16] = fast_uninitialized!(16);
   local_array.clone_from_slice(fast!((data)[off_src as usize ; off_src as usize + 16]));
   fast_mut!((data)[off_dst as usize ; off_dst as usize + 16]).clone_from_slice(&local_array);
-
-
 }
 
-
+#[inline(always)]
 #[cfg(not(feature="unsafe"))]
 fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: usize) {
   if off_dst > off_src {
@@ -2125,6 +2128,7 @@ fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: us
   }
 }
 
+#[inline(always)]
 #[cfg(feature="unsafe")]
 fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: usize) {
   let ptr = data.as_mut_ptr();
@@ -2212,6 +2216,7 @@ pub fn BrotliDecoderGetErrorCode<AllocU8: alloc::Allocator<u8>,
   s.error_code
 }
 
+#[inline(always)]
 fn ProcessCommandsInternal<AllocU8: alloc::Allocator<u8>,
                            AllocU32: alloc::Allocator<u32>,
                            AllocHC: alloc::Allocator<HuffmanCode>>


### PR DESCRIPTION
We profiled rust-brotli and found that forcing inlining for some functions improves decompression speed by 10-30%.

A microbenchmark decompressing a file (178kb uncompressed) 5000 times showed the following numbers under different compression qualities:

| Quality | Time (base) | Rate (base) | Time (PR) | Rate (PR)   | Improvement |
| ------- | ----------- | ----------- | --------- | ----------- | ----------- |
|       1 |     7.630 s | 111.79 MB/s |   5.091 s | 167.53 MB/s |        33 % |
|       5 |     5.812 s | 146.76 MB/s |   4.187 s | 203.71 MB/s |        28 % |
|      10 |     5.854 s | 145.70 MB/s |   5.212 s | 163.66 MB/s |        11 % |
|      15 |     5.658 s | 150.76 MB/s |   4.987 s | 171.05 MB/s |        12 % |

The libraries own benchmark shows a similar improvement. As far as I can tell, alice29.txt.compressed was generated roughly with quality 10. Results:

    $ cargo test --release --features=benchmark -- benchmark_alice29
    # base
    1000 Iterations; Time 0.670022145
    # PR
    1000 Iterations; Time 0.586202800