### PR TITLE
Validate raw pointers/sizes to avoid precondition aborts

### DIFF
--- a/src/bin/brotli-decompressor.rs
+++ b/src/bin/brotli-decompressor.rs
@@ -1,10 +1,12 @@
 #![allow(unused_imports)]
 // Assert at compile time that the default build contains no unsafe code:
-// the only unsafe in this binary lives behind the "unsafe" and "seccomp" features.
-#![cfg_attr(not(any(feature="unsafe", feature="seccomp")), forbid(unsafe_code))]
+// the only unsafe in this binary lives behind the "unsafe" and "seccomp"
+// features, plus the ffi-api test module.
+#![cfg_attr(not(any(feature="unsafe", feature="seccomp", all(test, feature="ffi-api"))), forbid(unsafe_code))]
 
 mod integration_tests;
 mod error_handling_tests;
+mod ffi_stream_tests;
 mod tests;
 extern crate brotli_decompressor;
 extern crate core;

--- a/src/bin/ffi_stream_tests.rs
+++ b/src/bin/ffi_stream_tests.rs
@@ -1,0 +1,112 @@
+#![cfg(test)]
+#![cfg(all(feature = "ffi-api", feature = "std"))]
+
+use std::mem;
+use std::ptr;
+
+use brotli_decompressor::ffi::interface::BrotliDecoderResult;
+use brotli_decompressor::ffi::{
+  BrotliDecoderCreateInstance, BrotliDecoderDecompressStream, BrotliDecoderDestroyInstance,
+  BrotliDecoderErrorCode,
+};
+
+#[test]
+fn stream_rejects_null_input_buffer_with_nonzero_length() {
+  let state = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
+  assert!(!state.is_null());
+
+  let mut available_in = 1usize;
+  let mut input = ptr::null();
+  let mut available_out = 0usize;
+  let mut output = ptr::null_mut();
+  let result = unsafe {
+    BrotliDecoderDecompressStream(
+      state,
+      &mut available_in,
+      &mut input,
+      &mut available_out,
+      &mut output,
+      ptr::null_mut(),
+    )
+  };
+
+  assert_eq!(
+    result as i32,
+    BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR as i32,
+  );
+  assert_eq!(
+    unsafe { (*state).decompressor.error_code } as i32,
+    BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS as i32,
+  );
+  unsafe { BrotliDecoderDestroyInstance(state) };
+}
+
+#[test]
+fn stream_rejects_wrapping_input_range() {
+  let state = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
+  assert!(!state.is_null());
+
+  let mut available_in = 1usize;
+  let mut input = usize::MAX as *const u8;
+  let mut available_out = 0usize;
+  let mut output = ptr::null_mut();
+  let result = unsafe {
+    BrotliDecoderDecompressStream(
+      state,
+      &mut available_in,
+      &mut input,
+      &mut available_out,
+      &mut output,
+      ptr::null_mut(),
+    )
+  };
+
+  assert_eq!(
+    result as i32,
+    BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR as i32,
+  );
+  assert_eq!(
+    unsafe { (*state).decompressor.error_code } as i32,
+    BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS as i32,
+  );
+  unsafe { BrotliDecoderDestroyInstance(state) };
+}
+
+#[test]
+fn stream_advances_the_original_output_pointer() {
+  static ENCODED_FF_BYTES: &'static [u8] = b"\x1f\x07\x00\xf8\x27\xfe\x43\x84\x00\x00";
+
+  let state = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
+  assert!(!state.is_null());
+
+  let mut available_in = ENCODED_FF_BYTES.len();
+  let mut input = ENCODED_FF_BYTES.as_ptr();
+  let mut available_out = mem::size_of::<*mut u8>();
+  let mut output = ptr::null_mut();
+  let output_storage = &mut output as *mut *mut u8 as *mut u8;
+  output = output_storage;
+
+  // Decoding 0xff bytes overwrites `output` with usize::MAX. The cursor
+  // must advance the original pointer instead of offsetting that value.
+  let result = unsafe {
+    BrotliDecoderDecompressStream(
+      state,
+      &mut available_in,
+      &mut input,
+      &mut available_out,
+      &mut output,
+      ptr::null_mut(),
+    )
+  };
+
+  assert_ne!(
+    result as i32,
+    BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR as i32,
+  );
+  assert_eq!(available_out, 0);
+  assert_eq!(
+    output,
+    output_storage.wrapping_add(mem::size_of::<*mut u8>()),
+  );
+  unsafe { BrotliDecoderDestroyInstance(state) };
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -30,6 +30,53 @@ pub unsafe fn slice_from_raw_parts_or_nil_mut<'a, T>(data: *mut T, len: usize) -
     slice::from_raw_parts_mut(data, len)
 }
 
+trait MaxSliceLen {
+    const MAX_SLICE_LEN: usize;
+}
+
+impl<T> MaxSliceLen for T {
+    const MAX_SLICE_LEN: usize = if core::mem::size_of::<T>() == 0 {
+        usize::MAX
+    } else {
+        (isize::MAX as usize) / core::mem::size_of::<T>()
+    };
+}
+
+// Rejects the pointer/length pairs that would make `slice::from_raw_parts` trip a
+// non-unwinding "unsafe precondition" panic not catchable by `catch_unwind`.
+fn is_valid_slice_ptr<T>(data: *const T, len: usize) -> bool {
+    if len == 0 {
+        return true;
+    }
+    if data.is_null() {
+        return false;
+    }
+    if len > T::MAX_SLICE_LEN {
+        return false;
+    }
+    (data as usize).checked_add(len * core::mem::size_of::<T>()).is_some()
+}
+
+unsafe fn checked_slice_from_raw_parts_or_nil<'a, T>(
+    data: *const T,
+    len: usize,
+) -> Option<&'a [T]> {
+    if !is_valid_slice_ptr(data, len) {
+        return None;
+    }
+    Some(slice_from_raw_parts_or_nil(data, len))
+}
+
+unsafe fn checked_slice_from_raw_parts_or_nil_mut<'a, T>(
+    data: *mut T,
+    len: usize,
+) -> Option<&'a mut [T]> {
+    if !is_valid_slice_ptr(data, len) {
+        return None;
+    }
+    Some(slice_from_raw_parts_or_nil_mut(data, len))
+}
+
 #[cfg(feature="std")]
 type BrotliAdditionalErrorData = boxed::Box<dyn any::Any + Send + 'static>;
 #[cfg(not(feature="std"))]
@@ -218,6 +265,17 @@ pub unsafe extern fn BrotliDecoderDecompressStream(
     available_out: *mut usize,
     output_buf_ptr: *mut*mut u8,
     mut total_out: *mut usize) -> BrotliDecoderResult {
+    if state_ptr.is_null() ||
+       available_in.is_null() ||
+       input_buf_ptr.is_null() ||
+       available_out.is_null() ||
+       output_buf_ptr.is_null() {
+        if !state_ptr.is_null() {
+            (*state_ptr).decompressor.error_code =
+                BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS;
+        }
+        return BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR;
+    }
     match catch_panic(move || {
     let mut input_offset = 0usize;
     let mut output_offset = 0usize;
@@ -226,9 +284,31 @@ pub unsafe extern fn BrotliDecoderDecompressStream(
         total_out = &mut fallback_total_out;
     }
     let result: BrotliDecoderResult;
+    let input_ptr = *input_buf_ptr;
+    let output_ptr = *output_buf_ptr;
     {
-        let input_buf = slice_from_raw_parts_or_nil(*input_buf_ptr, *available_in);
-        let output_buf = slice_from_raw_parts_or_nil_mut(*output_buf_ptr, *available_out);
+        let input_buf = match checked_slice_from_raw_parts_or_nil(
+            input_ptr,
+            *available_in,
+        ) {
+            Some(input_buf) => input_buf,
+            None => {
+                (*state_ptr).decompressor.error_code =
+                    BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS;
+                return BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR;
+            },
+        };
+        let output_buf = match checked_slice_from_raw_parts_or_nil_mut(
+            output_ptr,
+            *available_out,
+        ) {
+            Some(output_buf) => output_buf,
+            None => {
+                (*state_ptr).decompressor.error_code =
+                    BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS;
+                return BrotliDecoderResult::BROTLI_DECODER_RESULT_ERROR;
+            },
+        };
             result = super::decode::BrotliDecompressStream(
                 &mut *available_in,
                 &mut input_offset,
@@ -240,8 +320,8 @@ pub unsafe extern fn BrotliDecoderDecompressStream(
                 &mut (*state_ptr).decompressor,
             ).into();
     }
-    *input_buf_ptr = (*input_buf_ptr).offset(input_offset as isize);
-    *output_buf_ptr = (*output_buf_ptr).offset(output_offset as isize);
+    *input_buf_ptr = input_ptr.offset(input_offset as isize);
+    *output_buf_ptr = output_ptr.offset(output_offset as isize);
                                            result
     }) {
         Ok(ret) => ret,


### PR DESCRIPTION
`BrotliDecoderDecompressStream` accepts raw C pointers and passes them straight to `slice::from_raw_parts` and `ptr::offset`. Rust enforces the preconditions of those APIs with **non-unwinding** panics, which abort the process immediately, they are not caught by `catch_panic` wrapper.

Check the pointers and sizes to avoid aborts.