### PR TITLE
Clamp uncompressed metablock copy length as unsigned to prevent OOB write

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1765,20 +1765,16 @@ fn CopyUncompressedBlockToOutput<AllocU8: alloc::Allocator<u8>,
   loop {
     match s.substate_uncompressed {
       BrotliRunningUncompressedState::BROTLI_STATE_UNCOMPRESSED_NONE => {
-        let mut nbytes = bit_reader::BrotliGetRemainingBytes(&s.br) as i32;
-        if (nbytes > s.meta_block_remaining_len) {
-          nbytes = s.meta_block_remaining_len;
-        }
-        if (s.pos + nbytes > s.ringbuffer_size) {
-          nbytes = s.ringbuffer_size - s.pos;
-        }
+        let remaining = bit_reader::BrotliGetRemainingBytes(&s.br);
+        let mut nbytes = core::cmp::min(remaining, s.meta_block_remaining_len as u32);
+        nbytes = core::cmp::min(nbytes, (s.ringbuffer_size - s.pos) as u32);
         // Copy remaining bytes from s.br.buf_ to ringbuffer.
         bit_reader::BrotliCopyBytes(fast_mut!((s.ringbuffer.slice_mut())[s.pos as usize;]),
                                     &mut s.br,
-                                    nbytes as u32,
+                                    nbytes,
                                     input);
-        s.pos += nbytes;
-        s.meta_block_remaining_len -= nbytes;
+        s.pos += nbytes as i32;
+        s.meta_block_remaining_len -= nbytes as i32;
         if s.pos < (1 << s.window_bits) {
           if (s.meta_block_remaining_len == 0) {
             return BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS;
@@ -1893,6 +1889,46 @@ mod tests {
   fn canny_ring_buffer() {
     assert_eq!(ringbuffer_size(true), 32);
     assert_eq!(ringbuffer_size(false), 1 << 16);
+  }
+
+  fn assert_large_remaining_copy_is_clamped(meta_block_remaining_len: i32,
+                                            pos: i32,
+                                            expected_result: BrotliDecoderErrorCode) {
+    let mut s = BrotliState::new(::StandardAlloc::default(),
+                                 ::StandardAlloc::default(),
+                                 ::StandardAlloc::default());
+    s.ringbuffer_size = 16;
+    s.window_bits = 5;
+    s.ringbuffer = s.alloc_u8.alloc_cell(s.ringbuffer_size as usize);
+    s.meta_block_remaining_len = meta_block_remaining_len;
+    s.pos = pos;
+    s.br.avail_in = 1u32 << 31;
+
+    let input = [0x5au8];
+    let mut available_out = 0usize;
+    let mut output = [0u8; 0];
+    let mut output_offset = 0usize;
+    let mut total_out = 0usize;
+    let result = CopyUncompressedBlockToOutput(&mut available_out,
+                                               &mut output,
+                                               &mut output_offset,
+                                               &mut total_out,
+                                               &mut s,
+                                               &input);
+
+    assert_eq!(result as i32, expected_result as i32);
+    assert_eq!(s.br.avail_in, (1u32 << 31) - 1);
+    assert_eq!(s.meta_block_remaining_len, meta_block_remaining_len - 1);
+    assert_eq!(s.pos, pos + 1);
+    assert_eq!(s.ringbuffer.slice()[pos as usize], input[0]);
+  }
+
+  #[test]
+  fn uncompressed_copy_clamps_unsigned_remaining_bytes() {
+    assert_large_remaining_copy_is_clamped(
+      1, 0, BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS);
+    assert_large_remaining_copy_is_clamped(
+      16, 15, BrotliDecoderErrorCode::BROTLI_DECODER_NEEDS_MORE_INPUT);
   }
 }
 


### PR DESCRIPTION
`CopyUncompressedBlockToOutput` narrowed the remaining-byte count from `u32` to `i32`. When a single `BrotliDecompressStream` call receives `available_in` in [2³¹, 2³²) (a range the entry guard admits) the count sign-flips negative, both `>` clamps (metablock length, ring-buffer space) pass, and the value is cast back to `u32`, so `BrotliCopyBytes` copies ~2 GiB into a ≤16 MiB ring buffer.

- Default build: attacker-triggered panic (`index out of bounds` in `BrotliCopyBytes`) causing a DoS.
- `--features unsafe`: sequential heap out-of-bounds **write** of attacker-controlled bytes.

## Fix

Keep the count unsigned and clamp with `min()` before any signed conversion. Both clamp operands are non-negative (`meta_block_remaining_len ≤ 2²⁴+1`, `pos ≤ ringbuffer_size`), so the casts are value-preserving and the copy can never exceed either bound.

Fix [GHSA-mfjf-j6gx-j4fw](https://github.com/dropbox/rust-brotli-decompressor/security/advisories/GHSA-mfjf-j6gx-j4fw)