### PR TITLE
Fix FFI return info field order

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -63,10 +63,15 @@ void negative_test() {
     unsigned char obuffer[4096];
     size_t total_out = 0;
     const unsigned char *i_ptr = &brotli_file[0];
+    BrotliDecoderReturnInfo return_info =
+        BrotliDecoderDecompressWithReturnInfo(
+            sizeof(brotli_file), brotli_file, sizeof(obuffer), obuffer);
 
     unsigned char *o_ptr = &obuffer[0];
     const char * to_be_printed;
     BrotliDecoderResult rest = BrotliDecoderDecompressStream(state, &avail_in, &i_ptr, &avail_out, &o_ptr, &total_out);
+    assert(return_info.result == BROTLI_DECODER_RESULT_ERROR);
+    assert(return_info.code == BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT);
     assert(rest ==  BROTLI_DECODER_RESULT_ERROR);
     to_be_printed = BrotliDecoderGetErrorString(state);
     assert(strcmp(to_be_printed, "ERROR_FORMAT_CONTEXT_MAP_REPEAT") == 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,8 +337,8 @@ pub fn copy_from_to<R: io::Read, W: io::Write>(mut r: R, mut w: W) -> io::Result
 pub struct BrotliDecoderReturnInfo {
     pub decoded_size: usize,
     pub error_string: [u8;256],
-    pub error_code: state::BrotliDecoderErrorCode,
     pub result: BrotliResult,
+    pub error_code: state::BrotliDecoderErrorCode,
 }
 impl BrotliDecoderReturnInfo {
     fn new<AllocU8: Allocator<u8>,


### PR DESCRIPTION
Aligns `BrotliDecoderReturnInfo` with the C ABI and adds a regression test for decode error reporting.