### PR TITLE
Check block length tree allocation failures

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2873,6 +2873,10 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
           }
           s.block_type_length_state.block_len_trees = s.alloc_hc
             .alloc_cell(3 * huffman::BROTLI_HUFFMAN_MAX_TABLE_SIZE as usize);
+          if (s.block_type_length_state.block_len_trees.slice().len() == 0) {
+            result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES;
+            break;
+          }
 
           s.state = BrotliRunningState::BROTLI_STATE_METABLOCK_BEGIN;
           // No break, continue to next state

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,7 +14,38 @@ pub use super::{BrotliDecompressStream, BrotliResult, BrotliState, HuffmanCode};
 
 declare_stack_allocator_struct!(MemPool, 4096, stack);
 
+struct FailSecondBlockTreeAllocation<AllocHC> {
+  alloc: AllocHC,
+  block_tree_allocations: u8,
+}
 
+impl<AllocHC> FailSecondBlockTreeAllocation<AllocHC> {
+  fn new(alloc: AllocHC) -> Self {
+    FailSecondBlockTreeAllocation {
+      alloc,
+      block_tree_allocations: 0,
+    }
+  }
+}
+
+impl<AllocHC: Allocator<HuffmanCode>> Allocator<HuffmanCode>
+  for FailSecondBlockTreeAllocation<AllocHC> {
+  type AllocatedMemory = AllocHC::AllocatedMemory;
+
+  fn alloc_cell(&mut self, len: usize) -> Self::AllocatedMemory {
+    if len == 3 * super::huffman::BROTLI_HUFFMAN_MAX_TABLE_SIZE as usize {
+      self.block_tree_allocations += 1;
+      if self.block_tree_allocations == 2 {
+        return Self::AllocatedMemory::default();
+      }
+    }
+    self.alloc.alloc_cell(len)
+  }
+
+  fn free_cell(&mut self, data: Self::AllocatedMemory) {
+    self.alloc.free_cell(data);
+  }
+}
 
 fn oneshot(input: &mut [u8], mut output: &mut [u8]) -> (BrotliResult, usize, usize) {
   let mut available_out: usize = output.len();
@@ -42,6 +73,47 @@ fn oneshot(input: &mut [u8], mut output: &mut [u8]) -> (BrotliResult, usize, usi
                                       &mut written,
                                       &mut brotli_state);
   return (result, input_offset, output_offset);
+}
+
+#[test]
+fn test_block_len_trees_allocation_failure() {
+  let input = [0x06u8];
+  let mut output = [0u8; 1];
+  let mut stack_u8_buffer = define_allocator_memory_pool!(4096, u8, [0; 16 * 1024], stack);
+  let mut stack_u32_buffer = define_allocator_memory_pool!(4096, u32, [0; 4 * 1024], stack);
+  let mut stack_hc_buffer = define_allocator_memory_pool!(4096,
+                                                          HuffmanCode,
+                                                          [HuffmanCode::default(); 20 * 1024],
+                                                          stack);
+  let stack_u8_allocator = MemPool::<u8>::new_allocator(&mut stack_u8_buffer, bzero);
+  let stack_u32_allocator = MemPool::<u32>::new_allocator(&mut stack_u32_buffer, bzero);
+  let stack_hc_allocator =
+    FailSecondBlockTreeAllocation::new(MemPool::<HuffmanCode>::new_allocator(&mut stack_hc_buffer,
+                                                                             bzero));
+  let mut state = BrotliState::new(stack_u8_allocator, stack_u32_allocator, stack_hc_allocator);
+  let mut available_in = input.len();
+  let mut input_offset = 0;
+  let mut available_out = output.len();
+  let mut output_offset = 0;
+  let mut total_out = 0;
+
+  let result = BrotliDecompressStream(&mut available_in,
+                                      &mut input_offset,
+                                      &input,
+                                      &mut available_out,
+                                      &mut output_offset,
+                                      &mut output,
+                                      &mut total_out,
+                                      &mut state);
+
+  match result {
+    BrotliResult::ResultFailure => {}
+    _ => panic!("block_len_trees allocation failure must fail decoding"),
+  }
+  match state.error_code {
+    super::state::BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES => {}
+    _ => panic!("unexpected decoder error after block_len_trees allocation failure"),
+  }
 }
 
 // no-std variant of oneshot that seeds the decoder with a custom dictionary.


### PR DESCRIPTION
Checks `block_len_trees` allocation before use and returns the existing allocation error on failure. Adds regression coverage using a fallible allocator to prevent unchecked Huffman-table access.