### PR TITLE
Handle null FFI allocator returns

### DIFF
--- a/src/ffi/alloc_util.rs
+++ b/src/ffi/alloc_util.rs
@@ -74,6 +74,9 @@ impl<Ty:Sized+Default+Clone> alloc::Allocator<Ty> for SubclassableAllocator {
         }
         if let Some(alloc_fn) = self.alloc.alloc_func {
             let ptr = alloc_fn(self.alloc.opaque, size * core::mem::size_of::<Ty>());
+            if ptr.is_null() {
+                return MemoryBlock::<Ty>::default();
+            }
             let typed_ptr = unsafe {core::mem::transmute::<*mut c_void, *mut Ty>(ptr)};
             let slice_ref = unsafe {super::slice_from_raw_parts_or_nil_mut(typed_ptr, size)};
             for item in slice_ref.iter_mut() {
@@ -175,6 +178,9 @@ impl<Ty:Sized+Default+Clone> alloc::Allocator<Ty> for SubclassableAllocator {
         }
         if let Some(alloc_fn) = self.alloc.alloc_func {
             let ptr = alloc_fn(self.alloc.opaque, size * core::mem::size_of::<Ty>());
+            if ptr.is_null() {
+                return MemoryBlock::<Ty>::default();
+            }
             let typed_ptr = unsafe {core::mem::transmute::<*mut c_void, *mut Ty>(ptr)};
             let slice_ref = unsafe {super::slice_from_raw_parts_or_nil_mut(typed_ptr, size)};
             for item in slice_ref.iter_mut() {
@@ -225,4 +231,28 @@ pub fn alloc_stdlib<T:Sized+Default+Copy+Clone>(size: usize) -> *mut T {
         let _box_ptr = Box::into_raw(newly_allocated);
         slice_ptr
     }).unwrap_or(core::ptr::null_mut())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::alloc::{Allocator, SliceWrapper};
+
+    extern "C" fn failing_alloc(_data: *mut c_void, _size: usize) -> *mut c_void {
+        core::ptr::null_mut()
+    }
+
+    #[test]
+    fn failed_custom_allocation_returns_empty_block() {
+        let c_allocator = CAllocator {
+            alloc_func: Some(failing_alloc),
+            free_func: None,
+            opaque: core::ptr::null_mut(),
+        };
+        let mut allocator = unsafe { SubclassableAllocator::new(c_allocator) };
+        let block =
+            <SubclassableAllocator as Allocator<u8>>::alloc_cell(&mut allocator, 1);
+
+        assert_eq!(block.slice().len(), 0);
+    }
 }


### PR DESCRIPTION
Treat NULL returns from custom FFI allocators as allocation failures in both std and no-std builds. The allocator now returns an empty `MemoryBlock`, allowing existing `BROTLI_DECODER_ERROR_ALLOC_*` paths to handle the failure instead of writing through a null pointer.