### PR TITLE
Fix null pointer handling in FFI free path

### DIFF
--- a/src/bin/ffi_stream_tests.rs
+++ b/src/bin/ffi_stream_tests.rs
@@ -7,8 +7,20 @@ use std::ptr;
 use brotli_decompressor::ffi::interface::BrotliDecoderResult;
 use brotli_decompressor::ffi::{
   BrotliDecoderCreateInstance, BrotliDecoderDecompressStream, BrotliDecoderDestroyInstance,
-  BrotliDecoderErrorCode, BrotliDecoderIsUsed,
+  BrotliDecoderErrorCode, BrotliDecoderFreeU8, BrotliDecoderFreeUsize, BrotliDecoderIsUsed,
 };
+
+#[test]
+fn default_allocator_free_ignores_null() {
+  let state = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
+  assert!(!state.is_null());
+
+  unsafe {
+    BrotliDecoderFreeU8(state, ptr::null_mut(), 64);
+    BrotliDecoderFreeUsize(state, ptr::null_mut(), 64);
+    BrotliDecoderDestroyInstance(state);
+  }
+}
 
 #[test]
 fn stream_rejects_null_input_buffer_with_nonzero_length() {

--- a/src/ffi/alloc_util.rs
+++ b/src/ffi/alloc_util.rs
@@ -214,6 +214,9 @@ pub fn alloc_stdlib<T:Sized+Default+Copy+Clone>(_size: usize) -> *mut T {
 
 #[cfg(feature="std")]
 pub unsafe fn free_stdlib<T>(ptr: *mut T, size: usize) {
+    if ptr.is_null() {
+        return;
+    }
     let slice_ref = super::slice_from_raw_parts_or_nil_mut(ptr, size);
     let _ = Box::from_raw(slice_ref); // free on drop
 }


### PR DESCRIPTION
Treat null pointers passed to the default FFI deallocator as a no-op, matching the Brotli allocator contract and avoid panics from slice creation and UB from box.