### PR TITLE
Avoid decoder panics on malformed streams

### DIFF
--- a/src/bit_reader/mod.rs
+++ b/src/bit_reader/mod.rs
@@ -89,6 +89,17 @@ pub fn BrotliGetAvailableBits(br: &BrotliBitReader) -> u32 {
   ((::core::mem::size_of::<reg_t>() as u32) << 3) - br.bit_pos_
 }
 
+pub fn is_valid_bit_reader(br: &BrotliBitReader, input: &[u8]) -> bool {
+  let register_bits = (::core::mem::size_of::<reg_t>() as u32) << 3;
+  if br.bit_pos_ > register_bits {
+    return false;
+  }
+  match (br.next_in as usize).checked_add(br.avail_in as usize) {
+    Some(input_end) => input_end <= input.len(),
+    None => false,
+  }
+}
+
 // Returns amount of unread bytes the bit reader still has buffered from the
 // BrotliInput, including whole bytes in br->val_.
 pub fn BrotliGetRemainingBytes(br: &BrotliBitReader) -> u32 {
@@ -389,15 +400,27 @@ pub fn BrotliJumpToByteBoundary(br: &mut BrotliBitReader) -> bool {
 // Returns -1 if operation is not feasible.
 #[allow(dead_code)]
 pub fn BrotliPeekByte(br: &mut BrotliBitReader, mut offset: u32, input: &[u8]) -> i32 {
+  if !is_valid_bit_reader(br, input) {
+    return -1;
+  }
   let available_bits: u32 = BrotliGetAvailableBits(br);
   let bytes_left: u32 = (available_bits >> 3);
-  assert!((available_bits & 7) == 0);
+  if (available_bits & 7) != 0 {
+    return -1;
+  }
   if offset < bytes_left {
     return ((BrotliGetBitsUnmasked(br) >> ((offset << 3)) as u32) & 0xFF) as i32;
   }
   offset -= bytes_left;
   if offset < br.avail_in {
-    return fast!((input)[br.next_in as usize + offset as usize]) as i32;
+    let input_index = match (br.next_in as usize).checked_add(offset as usize) {
+      Some(index) => index,
+      None => return -1,
+    };
+    return match input.get(input_index) {
+      Some(value) => *value as i32,
+      None => -1,
+    };
   }
   -1
 }
@@ -450,6 +473,26 @@ pub fn BrotliWarmupBitReader(br: &mut BrotliBitReader, input: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn peek_byte_rejects_invalid_state() {
+    let data: [u8; 1] = [0x7f];
+    let mut unaligned_reader = BrotliBitReader {
+      val_: 0,
+      bit_pos_: 1,
+      avail_in: 0,
+      next_in: 0,
+    };
+    assert_eq!(BrotliPeekByte(&mut unaligned_reader, 0, &data), -1);
+
+    let mut out_of_bounds_reader = BrotliBitReader {
+      val_: 0,
+      bit_pos_: 64,
+      avail_in: 1,
+      next_in: 1,
+    };
+    assert_eq!(BrotliPeekByte(&mut out_of_bounds_reader, 0, &data), -1);
+  }
 
   #[test]
   fn warmup_works() {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -876,6 +876,9 @@ fn ReadHuffmanCode<AllocU8: alloc::Allocator<u8>,
    s: &mut BrotliState<AllocU8, AllocU32, AllocHC>,
    input: &[u8])
    -> BrotliDecoderErrorCode {
+  if offset > table.len() {
+    return BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE;
+  }
   // Unnecessary masking, but might be good for safety.
   alphabet_size &= 0x7ff;
   // State machine
@@ -942,6 +945,9 @@ fn ReadHuffmanCode<AllocU8: alloc::Allocator<u8>,
                                                             HUFFMAN_TABLE_BITS as i32,
                                                             &s.symbols_lists_array[..],
                                                             s.symbol);
+        if table_size == 0 {
+          return BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE;
+        }
         if let Some(opt_table_size_ref) = opt_table_size {
           *opt_table_size_ref = table_size
         }
@@ -957,9 +963,13 @@ fn ReadHuffmanCode<AllocU8: alloc::Allocator<u8>,
           BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS => {}
           _ => return result,
         }
-        huffman::BrotliBuildCodeLengthsHuffmanTable(&mut s.table,
-                                                    &s.code_length_code_lengths,
-                                                    &s.code_length_histo);
+        if !huffman::BrotliBuildCodeLengthsHuffmanTable(
+          &mut s.table,
+          &s.code_length_code_lengths,
+          &s.code_length_histo,
+        ) {
+          return BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE;
+        }
         for code_length_histo in s.code_length_histo[..].iter_mut() {
           *code_length_histo = 0; // memset
         }
@@ -1002,6 +1012,9 @@ fn ReadHuffmanCode<AllocU8: alloc::Allocator<u8>,
                                                       &s.symbols_lists_array[..],
                                                       s.symbol_lists_index,
                                                       &mut s.code_length_histo);
+        if table_size == 0 {
+          return BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE;
+        }
         if let Some(opt_table_size_ref) = opt_table_size {
           *opt_table_size_ref = table_size
         }
@@ -1437,9 +1450,9 @@ fn DecodeContextMap<AllocU8: alloc::Allocator<u8>,
    -> BrotliDecoderErrorCode {
 
   match s.state {
-    BrotliRunningState::BROTLI_STATE_CONTEXT_MAP_1 => assert_eq!(is_dist_context_map, false),
-    BrotliRunningState::BROTLI_STATE_CONTEXT_MAP_2 => assert_eq!(is_dist_context_map, true),
-    _ => unreachable!(),
+    BrotliRunningState::BROTLI_STATE_CONTEXT_MAP_1 if !is_dist_context_map => {},
+    BrotliRunningState::BROTLI_STATE_CONTEXT_MAP_2 if is_dist_context_map => {},
+    _ => return BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE,
   }
   let (mut num_htrees, mut context_map_arg) = if is_dist_context_map {
     (s.num_dist_htrees, mem::replace(&mut s.dist_context_map, AllocU8::AllocatedMemory::default()))
@@ -1681,14 +1694,25 @@ fn UnwrittenBytes<AllocU8: alloc::Allocator<u8>,
                   AllocHC: alloc::Allocator<HuffmanCode>> (
   s: &BrotliState<AllocU8, AllocU32, AllocHC>,
   wrap: bool,
-)  -> usize {
+)  -> Option<usize> {
+  if s.pos < 0 || s.ringbuffer_size < 0 {
+    return None;
+  }
+  let ringbuffer_size = s.ringbuffer_size as usize;
   let pos = if wrap && s.pos > s.ringbuffer_size {
-    s.ringbuffer_size as usize
+    ringbuffer_size
   } else {
     s.pos as usize
   };
-  let partial_pos_rb = (s.rb_roundtrips as usize * s.ringbuffer_size as usize) + pos as usize;
-  (partial_pos_rb - s.partial_pos_out) as usize
+  let completed_rounds = match s.rb_roundtrips.checked_mul(ringbuffer_size) {
+    Some(completed_rounds) => completed_rounds,
+    None => return None,
+  };
+  let partial_pos_rb = match completed_rounds.checked_add(pos) {
+    Some(partial_pos_rb) => partial_pos_rb,
+    None => return None,
+  };
+  partial_pos_rb.checked_sub(s.partial_pos_out)
 }
 fn WriteRingBuffer<'a,
                    AllocU8: alloc::Allocator<u8>,
@@ -1701,37 +1725,74 @@ fn WriteRingBuffer<'a,
   force: bool,
   s: &'a mut BrotliState<AllocU8, AllocU32, AllocHC>,
 ) -> (BrotliDecoderErrorCode, &'a [u8]) {
-  let to_write = UnwrittenBytes(s, true);
+  if s.meta_block_remaining_len < 0 {
+    return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1, &[]);
+  }
+  if s.ringbuffer_size <= 0 ||
+     s.ringbuffer_mask < 0 ||
+     s.ringbuffer_mask.checked_add(1) != Some(s.ringbuffer_size) {
+    return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]);
+  }
+  let to_write = match UnwrittenBytes(s, true) {
+    Some(to_write) => to_write,
+    None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+  };
   let mut num_written = *available_out as usize;
   if (num_written > to_write) {
     num_written = to_write;
   }
-  if (s.meta_block_remaining_len < 0) {
-    return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1, &[]);
+  if s.ringbuffer_size as usize > s.ringbuffer.slice().len() {
+    return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]);
   }
   let start_index = (s.partial_pos_out & s.ringbuffer_mask as usize) as usize;
-  let start = fast_slice!((s.ringbuffer)[start_index ; start_index + num_written as usize]);
+  let start_end = match start_index.checked_add(num_written) {
+    Some(start_end) => start_end,
+    None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+  };
+  let start = match s.ringbuffer.slice().get(start_index..start_end) {
+    Some(start) => start,
+    None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+  };
   if let Some(output) = opt_output {
-    fast_mut!((output)[*output_offset ; *output_offset + num_written as usize])
-      .clone_from_slice(start);
+    let output_end = match (*output_offset).checked_add(num_written) {
+      Some(output_end) => output_end,
+      None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS, &[]),
+    };
+    match output.get_mut(*output_offset..output_end) {
+      Some(output_slice) => output_slice.clone_from_slice(start),
+      None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS, &[]),
+    }
   }
-  *output_offset += num_written;
+  *output_offset = match (*output_offset).checked_add(num_written) {
+    Some(output_offset) => output_offset,
+    None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS, &[]),
+  };
   *available_out -= num_written;
   BROTLI_LOG_UINT!(to_write);
   BROTLI_LOG_UINT!(num_written);
-  s.partial_pos_out += num_written as usize;
+  s.partial_pos_out = match s.partial_pos_out.checked_add(num_written) {
+    Some(partial_pos_out) => partial_pos_out,
+    None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+  };
   *total_out = s.partial_pos_out;
+  let window_size = match 1i32.checked_shl(s.window_bits) {
+    Some(window_size) if window_size > 0 => window_size,
+    _ => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+  };
   if (num_written < to_write) {
-    if s.ringbuffer_size == (1 << s.window_bits) || force {
+    if s.ringbuffer_size == window_size || force {
       return (BrotliDecoderErrorCode::BROTLI_DECODER_NEEDS_MORE_OUTPUT, &[]);
     } else {
       return (BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS, start);
     }
   }
-  if (s.ringbuffer_size == (1 << s.window_bits) &&
+  if (s.ringbuffer_size == window_size &&
       s.pos >= s.ringbuffer_size) {
     s.pos -= s.ringbuffer_size;
-    s.rb_roundtrips += 1;
+    s.rb_roundtrips = match s.rb_roundtrips.checked_add(1) {
+      Some(rb_roundtrips) => rb_roundtrips,
+      None => return (BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE, &[]),
+    };
     s.should_wrap_ringbuffer = s.pos != 0;
   }
   (BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS, start)
@@ -1741,14 +1802,25 @@ fn WrapRingBuffer<AllocU8: alloc::Allocator<u8>,
                    AllocU32: alloc::Allocator<u32>,
                    AllocHC: alloc::Allocator<HuffmanCode>>(
   s: &mut BrotliState<AllocU8, AllocU32, AllocHC>,
-) {
+) -> bool {
   if s.should_wrap_ringbuffer {
-    let (ring_buffer_start, ring_buffer_end) = s.ringbuffer.slice_mut().split_at_mut(s.ringbuffer_size as usize);
+    if s.ringbuffer_size < 0 || s.pos < 0 {
+      return false;
+    }
+    let ringbuffer_size = s.ringbuffer_size as usize;
     let pos = s.pos as usize;
-    ring_buffer_start.split_at_mut(pos).0.clone_from_slice(ring_buffer_end.split_at(pos).0);
+    let ringbuffer_len = s.ringbuffer.slice().len();
+    if ringbuffer_size > ringbuffer_len ||
+       pos > ringbuffer_size ||
+       pos > ringbuffer_len - ringbuffer_size {
+      return false;
+    }
+    let (ring_buffer_start, ring_buffer_end) =
+      s.ringbuffer.slice_mut().split_at_mut(ringbuffer_size);
+    ring_buffer_start[..pos].clone_from_slice(&ring_buffer_end[..pos]);
     s.should_wrap_ringbuffer = false;
   }
-
+  true
 }
 
 fn CopyUncompressedBlockToOutput<AllocU8: alloc::Allocator<u8>,
@@ -2200,9 +2272,20 @@ fn CheckInputAmount(safe: bool, br: &bit_reader::BrotliBitReader, num: u32) -> b
 }
 
 #[inline(always)]
-fn memmove16(data: &mut [u8], u32off_dst: u32, u32off_src: u32) {
+fn memmove16(data: &mut [u8], u32off_dst: u32, u32off_src: u32) -> bool {
   let off_dst = u32off_dst as usize;
   let off_src = u32off_src as usize;
+  let dst_end = match off_dst.checked_add(16) {
+    Some(dst_end) => dst_end,
+    None => return false,
+  };
+  let src_end = match off_src.checked_add(16) {
+    Some(src_end) => src_end,
+    None => return false,
+  };
+  if dst_end > data.len() || src_end > data.len() {
+    return false;
+  }
   // data[off_dst + 15] = data[off_src + 15];
   // data[off_dst + 14] = data[off_src + 14];
   // data[off_dst + 13] = data[off_src + 13];
@@ -2223,33 +2306,47 @@ fn memmove16(data: &mut [u8], u32off_dst: u32, u32off_src: u32) {
   // data[off_dst + 1] = data[off_src + 1];
   //
   let mut local_array: [u8; 16] = fast_uninitialized!(16);
-  local_array.clone_from_slice(fast!((data)[off_src as usize ; off_src as usize + 16]));
-  fast_mut!((data)[off_dst as usize ; off_dst as usize + 16]).clone_from_slice(&local_array);
+  local_array.clone_from_slice(&data[off_src..src_end]);
+  data[off_dst..dst_end].clone_from_slice(&local_array);
+  true
 }
 
 #[inline(always)]
-#[cfg(not(feature="unsafe"))]
-fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: usize) {
-  if off_dst > off_src {
-    let (src, dst) = data.split_at_mut(off_dst);
-    let src_slice = fast!((src)[off_src ; off_src + size]);
-    fast_mut!((dst)[0;size]).clone_from_slice(src_slice);
-  } else {
-    let (dst, src) = data.split_at_mut(off_src);
-    let src_slice = fast!((src)[0;size]);
-    fast_mut!((dst)[off_dst;off_dst + size]).clone_from_slice(src_slice);
+fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: usize) -> bool {
+  let dst_end = match off_dst.checked_add(size) {
+    Some(end) => end,
+    None => return false,
+  };
+  let src_end = match off_src.checked_add(size) {
+    Some(end) => end,
+    None => return false,
+  };
+  if dst_end > data.len() || src_end > data.len() ||
+     (off_src < dst_end && off_dst < src_end) {
+    return false;
   }
-}
 
-#[inline(always)]
-#[cfg(feature="unsafe")]
-fn memcpy_within_slice(data: &mut [u8], off_dst: usize, off_src: usize, size: usize) {
-  let ptr = data.as_mut_ptr();
+  #[cfg(not(feature="unsafe"))]
+  {
+    if off_dst > off_src {
+      let (src, dst) = data.split_at_mut(off_dst);
+      let src_slice = fast!((src)[off_src ; src_end]);
+      fast_mut!((dst)[0;size]).clone_from_slice(src_slice);
+    } else {
+      let (dst, src) = data.split_at_mut(off_src);
+      let src_slice = fast!((src)[0;size]);
+      fast_mut!((dst)[off_dst;dst_end]).clone_from_slice(src_slice);
+    }
+  }
+
+  #[cfg(feature="unsafe")]
   unsafe {
-    let dst = ptr.offset(off_dst as isize);
-    let src = ptr.offset(off_src as isize);
+    let ptr = data.as_mut_ptr();
+    let dst = ptr.add(off_dst);
+    let src = ptr.add(off_src);
     core::ptr::copy_nonoverlapping(src, dst, size);
   }
+  true
 }
 
 pub fn BrotliDecoderHasMoreOutput<AllocU8: alloc::Allocator<u8>,
@@ -2260,7 +2357,10 @@ pub fn BrotliDecoderHasMoreOutput<AllocU8: alloc::Allocator<u8>,
   if is_fatal(s.error_code) {
     return false;
   }
-  s.ringbuffer.len() != 0 && UnwrittenBytes(s, false) != 0
+  s.ringbuffer.len() != 0 && match UnwrittenBytes(s, false) {
+    Some(unwritten_bytes) => unwritten_bytes != 0,
+    None => false,
+  }
 }
 pub fn BrotliDecoderTakeOutput<'a,
                                AllocU8: alloc::Allocator<u8>,
@@ -2276,7 +2376,11 @@ pub fn BrotliDecoderTakeOutput<'a,
     *size = 0;
     return &[];
   }
-  WrapRingBuffer(s);
+  if !WrapRingBuffer(s) {
+    s.error_code = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+    *size = 0;
+    return &[];
+  }
   let mut ign = 0usize;
   let mut ign2 = 0usize;
   let (status, result) = WriteRingBuffer(&mut available_out, None, &mut ign,&mut ign2, true, s);
@@ -2651,7 +2755,10 @@ fn ProcessCommandsInternal<AllocU8: alloc::Allocator<u8>,
             let dst_start = pos as u32;
             let dst_end = pos as u32 + i as u32;
             let src_end = src_start + i as u32;
-            memmove16(&mut s.ringbuffer.slice_mut(), dst_start, src_start);
+            if !memmove16(&mut s.ringbuffer.slice_mut(), dst_start, src_start) {
+              result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_DISTANCE;
+              break;
+            }
             // Now check if the copy extends over the ringbuffer end,
             // or if the copy overlaps with itself, if yes, do wrap-copy.
             if (src_end > pos as u32 && dst_end > src_start) {
@@ -2665,16 +2772,22 @@ fn ProcessCommandsInternal<AllocU8: alloc::Allocator<u8>,
             pos += i;
             if (i > 16) {
               if (i > 32) {
-                memcpy_within_slice(s.ringbuffer.slice_mut(),
-                                    dst_start as usize + 16,
-                                    src_start as usize + 16,
-                                    (i - 16) as usize);
+                if !memcpy_within_slice(s.ringbuffer.slice_mut(),
+                                        dst_start as usize + 16,
+                                        src_start as usize + 16,
+                                        (i - 16) as usize) {
+                  result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_DISTANCE;
+                  break;
+                }
               } else {
                 // This branch covers about 45% cases.
                 // Fixed size short copy allows more compiler optimizations.
-                memmove16(&mut s.ringbuffer.slice_mut(),
-                          dst_start + 16,
-                          src_start + 16);
+                if !memmove16(&mut s.ringbuffer.slice_mut(),
+                              dst_start + 16,
+                              src_start + 16) {
+                  result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_FORMAT_DISTANCE;
+                  break;
+                }
               }
             }
           }
@@ -2810,6 +2923,9 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
     Some(end) if end <= output.len() => {}
     _ => return SaveErrorCode!(s, BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_INVALID_ARGUMENTS),
   }
+  if s.buffer_length as usize > s.buffer.len() {
+    return SaveErrorCode!(s, BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE);
+  }
   if s.buffer_length == 0 {
     local_input = xinput;
     s.br.avail_in = *available_in as u32;
@@ -2862,10 +2978,13 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
                 // input stream.
                 result = BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS;
                 let new_byte = fast!((xinput)[*input_offset]);
-                fast_mut!((s.buffer)[s.buffer_length as usize]) = new_byte;
-                // we did the following copy upfront, so we wouldn't have to do it here
-                // since saved_buffer[s.buffer_length as usize] = new_byte violates borrow rules
-                assert_eq!(fast!((saved_buffer)[s.buffer_length as usize]), new_byte);
+                let buffer_length = s.buffer_length as usize;
+                // This byte was copied into saved_buffer at function entry.
+                if saved_buffer.get(buffer_length) != Some(&new_byte) {
+                  result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+                  break;
+                }
+                s.buffer[buffer_length] = new_byte;
                 s.buffer_length += 1;
                 s.br.avail_in = s.buffer_length;
                 (*input_offset) += 1;
@@ -2886,12 +3005,30 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
               // Copy tail to internal buffer and return.
               *input_offset = s.br.next_in as usize;
               *available_in = s.br.avail_in as usize;
-              while *available_in != 0 {
-                fast_mut!((s.buffer)[s.buffer_length as usize]) = fast!((xinput)[*input_offset]);
-                s.buffer_length += 1;
-                (*input_offset) += 1;
-                (*available_in) -= 1;
+              let buffer_length = s.buffer_length as usize;
+              let input_end = match (*input_offset).checked_add(*available_in) {
+                Some(end) => end,
+                None => {
+                  result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+                  break;
+                },
+              };
+              let buffer_end = match buffer_length.checked_add(*available_in) {
+                Some(end) => end,
+                None => {
+                  result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+                  break;
+                },
+              };
+              if input_end > xinput.len() || buffer_end > s.buffer.len() {
+                result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+                break;
               }
+              s.buffer[buffer_length..buffer_end]
+                .clone_from_slice(&xinput[*input_offset..input_end]);
+              s.buffer_length = buffer_end as u32;
+              *input_offset = input_end;
+              *available_in = 0;
               break;
             }
             // unreachable!(); <- dead code
@@ -2914,6 +3051,10 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
         }
         break;
       }
+    }
+    if !bit_reader::is_valid_bit_reader(&s.br, local_input) {
+      result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+      continue;
     }
     loop {
       // this emulates fallthrough behavior
@@ -3310,7 +3451,10 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
             BrotliDecoderErrorCode::BROTLI_DECODER_SUCCESS => {}
             _ => break,
           }
-          WrapRingBuffer(s);
+          if !WrapRingBuffer(s) {
+            result = BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE;
+            break;
+          }
           if s.ringbuffer_size == 1 << s.window_bits {
             s.max_distance = s.max_backward_distance;
           }
@@ -3400,4 +3544,30 @@ pub fn BrotliDecompressStream<AllocU8: alloc::Allocator<u8>,
   }
 
   SaveErrorCode!(s, result)
+}
+
+#[cfg(test)]
+mod safeguard_tests {
+  use super::{memcpy_within_slice, memmove16};
+
+  #[test]
+  fn memmove16_rejects_out_of_bounds_ranges() {
+    let mut data = [0u8; 16];
+    assert!(!memmove16(&mut data, 1, 0));
+    assert!(!memmove16(&mut data, 0, 1));
+  }
+
+  #[test]
+  fn memcpy_within_slice_validates_nonoverlapping_ranges() {
+    let mut data = [0u8, 1, 2, 3, 4, 5, 6, 7];
+    assert!(memcpy_within_slice(&mut data, 4, 0, 2));
+    assert_eq!(data, [0, 1, 2, 3, 0, 1, 6, 7]);
+
+    let unchanged = data;
+    assert!(!memcpy_within_slice(&mut data, 1, 0, 4));
+    assert!(!memcpy_within_slice(&mut data, 7, 0, 2));
+    assert!(!memcpy_within_slice(&mut data, usize::MAX, 0, 2));
+    assert!(!memcpy_within_slice(&mut data, 0, usize::MAX, 2));
+    assert_eq!(data, unchanged);
+  }
 }

--- a/src/huffman/mod.rs
+++ b/src/huffman/mod.rs
@@ -156,8 +156,11 @@ const BROTLI_REVERSE_BITS_LOWEST: u32 =
 // Returns reverse(num >> BROTLI_REVERSE_BITS_BASE, BROTLI_REVERSE_BITS_MAX),
 // where reverse(value, len) is the bit-wise reversal of the len least
 // significant bits of value.
-fn BrotliReverseBits(num: u32) -> u32 {
-  fast!((kReverseBits)[num as usize]) as u32
+fn BrotliReverseBits(num: u32) -> Option<u32> {
+  match kReverseBits.get(num as usize) {
+    Some(value) => Some(*value as u32),
+    None => None,
+  }
 }
 
 // Stores code in table[0], table[step], table[2*step], ..., table[end]
@@ -166,41 +169,111 @@ fn ReplicateValue(table: &mut [HuffmanCode],
                   offset: u32,
                   step: i32,
                   mut end: i32,
-                  code: HuffmanCode) {
+                  code: HuffmanCode) -> bool {
+  if step <= 0 || end <= 0 || end % step != 0 {
+    return false;
+  }
   loop {
     end -= step;
-    fast_mut!((table)[offset as usize + end as usize]) = code;
-    if end <= 0 {
+    let index = match (offset as usize).checked_add(end as usize) {
+      Some(index) => index,
+      None => return false,
+    };
+    match table.get_mut(index) {
+      Some(value) => *value = code,
+      None => return false,
+    }
+    if end == 0 {
       break;
     }
   }
+  true
 }
 
 // Returns the table width of the next 2nd level table. count is the histogram
 // of bit lengths for the remaining symbols, len is the code length of the next
 // processed symbol
-fn NextTableBitSize(count: &[u16], mut len: i32, root_bits: i32) -> i32 {
-  let mut left: i32 = 1 << (len - root_bits);
+fn NextTableBitSize(count: &[u16], mut len: i32, root_bits: i32) -> Option<i32> {
+  let shift = match len.checked_sub(root_bits) {
+    Some(shift) if shift >= 0 => shift as u32,
+    _ => return None,
+  };
+  let mut left = match 1i32.checked_shl(shift) {
+    Some(left) => left,
+    None => return None,
+  };
   while len < BROTLI_HUFFMAN_MAX_CODE_LENGTH as i32 {
-    left -= fast!((count)[len as usize]) as i32;
+    let count_value = match count.get(len as usize) {
+      Some(value) => *value as i32,
+      None => return None,
+    };
+    left = match left.checked_sub(count_value) {
+      Some(left) => left,
+      None => return None,
+    };
     if left <= 0 {
       break;
     }
     len += 1;
-    left <<= 1;
+    left = match left.checked_shl(1) {
+      Some(left) => left,
+      None => return None,
+    };
   }
-  len - root_bits
+  len.checked_sub(root_bits)
+}
+
+fn symbol_list_value(symbol_lists: &[u16],
+                     symbol_lists_offset: usize,
+                     relative_index: i32) -> Option<u16> {
+  let index = if relative_index < 0 {
+    let distance = match relative_index.checked_neg() {
+      Some(distance) => distance as usize,
+      None => return None,
+    };
+    match symbol_lists_offset.checked_sub(distance) {
+      Some(index) => index,
+      None => return None,
+    }
+  } else {
+    match symbol_lists_offset.checked_add(relative_index as usize) {
+      Some(index) => index,
+      None => return None,
+    }
+  };
+  match symbol_lists.get(index) {
+    Some(value) => Some(*value),
+    None => None,
+  }
 }
 
 
 pub fn BrotliBuildCodeLengthsHuffmanTable(mut table: &mut [HuffmanCode],
                                           code_lengths: &[u8],
-                                          count: &[u16]) {
+                                          count: &[u16]) -> bool {
   let mut sorted: [i32; 18] = fast_uninitialized![18];     /* symbols sorted by code length */
   // offsets in sorted table for each length
   let mut offset: [i32; (BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH + 1) as usize] =
     fast_uninitialized![(BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH + 1) as usize];
-  assert!(BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH as usize <= BROTLI_REVERSE_BITS_MAX as usize);
+  const table_size: i32 = 1 << BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH;
+  if BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH as usize > BROTLI_REVERSE_BITS_MAX ||
+     table.len() < table_size as usize ||
+     code_lengths.len() < sorted.len() ||
+     count.len() <= BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH as usize {
+    return false;
+  }
+  let mut actual_count =
+    [0u16; (BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH + 1) as usize];
+  for code_length in code_lengths.iter().take(sorted.len()) {
+    let code_length_index = *code_length as usize;
+    if code_length_index >= actual_count.len() {
+      return false;
+    }
+    actual_count[code_length_index] += 1;
+  }
+  if actual_count[1..] != count[1..actual_count.len()] {
+    return false;
+  }
 
   // generate offsets into sorted symbol table by code length
   let mut symbol: i32 = -1;         /* symbol index in original or sorted table */
@@ -227,8 +300,6 @@ pub fn BrotliBuildCodeLengthsHuffmanTable(mut table: &mut [HuffmanCode],
     }
   }
 
-  const table_size: i32 = 1 << BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH;
-
   // Special case: all symbols but one have 0 code length.
   if fast!((offset)[0]) == 0 {
     let code: HuffmanCode = HuffmanCode {
@@ -238,7 +309,7 @@ pub fn BrotliBuildCodeLengthsHuffmanTable(mut table: &mut [HuffmanCode],
     for val in fast_mut!((table)[0 ; table_size as usize]).iter_mut() {
       *val = code;
     }
-    return;
+    return true;
   }
 
   // fill in table
@@ -257,8 +328,17 @@ pub fn BrotliBuildCodeLengthsHuffmanTable(mut table: &mut [HuffmanCode],
     while bits_count != 0 {
       code.value = fast!((sorted)[symbol as usize]) as u16;
       symbol += 1;
-      ReplicateValue(&mut table, BrotliReverseBits(key), step, table_size, code);
-      key += key_step;
+      let reversed_key = match BrotliReverseBits(key) {
+        Some(reversed_key) => reversed_key,
+        None => return false,
+      };
+      if !ReplicateValue(&mut table, reversed_key, step, table_size, code) {
+        return false;
+      }
+      key = match key.checked_add(key_step) {
+        Some(key) => key,
+        None => return false,
+      };
       bits_count -= 1;
     }
     step <<= 1;
@@ -268,6 +348,7 @@ pub fn BrotliBuildCodeLengthsHuffmanTable(mut table: &mut [HuffmanCode],
       break;
     }
   }
+  true
 }
 
 pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
@@ -282,19 +363,31 @@ pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
   };       /* current table entry */
   let mut max_length: i32 = -1;
 
-  assert!(root_bits as isize <= BROTLI_REVERSE_BITS_MAX as isize);
-  assert!(BROTLI_HUFFMAN_MAX_CODE_LENGTH as isize - root_bits as isize <=
-          BROTLI_REVERSE_BITS_MAX as isize);
+  if root_bits <= 0 ||
+     root_bits as usize > BROTLI_REVERSE_BITS_MAX ||
+     BROTLI_HUFFMAN_MAX_CODE_LENGTH as i32 - root_bits >
+       BROTLI_REVERSE_BITS_MAX as i32 ||
+     symbol_lists_offset >= symbol_lists.len() {
+    return 0;
+  }
 
-  while fast!((symbol_lists)[((symbol_lists_offset as isize) + max_length as isize) as usize]) ==
-        0xFFFF {
+  while match symbol_list_value(symbol_lists, symbol_lists_offset, max_length) {
+    Some(value) => value == 0xFFFF,
+    None => return 0,
+  } {
     max_length -= 1;
   }
   max_length += BROTLI_HUFFMAN_MAX_CODE_LENGTH as i32 + 1;
+  if max_length < 0 || max_length as usize >= count.len() {
+    return 0;
+  }
 
   let mut table_free_offset: u32 = 0;
   let mut table_bits: i32 = root_bits;      /* key length of current table */
-  let mut table_size: i32 = 1 << table_bits;/* size of current table */
+  let mut table_size = match 1i32.checked_shl(table_bits as u32) {
+    Some(table_size) => table_size,
+    None => return 0,
+  };                                      /* size of current table */
   let mut total_size: i32 = table_size;     /* sum of root table size and 2nd level table sizes */
 
   // fill in root table
@@ -302,7 +395,10 @@ pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
   // create the repetitions by memcpy if possible in the coming loop
   if table_bits > max_length {
     table_bits = max_length;
-    table_size = 1 << table_bits;
+    table_size = match 1i32.checked_shl(table_bits as u32) {
+      Some(table_size) => table_size,
+      None => return 0,
+    };
   }
   let mut key: u32 = 0; /* prefix code */
   let mut key_step: u32 = BROTLI_REVERSE_BITS_LOWEST; /* prefix code addend */
@@ -313,15 +409,26 @@ pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
     let mut symbol: i32 = bits - (BROTLI_HUFFMAN_MAX_CODE_LENGTH as i32 + 1);
     let mut bits_count: i32 = fast!((count)[bits as usize]) as i32;
     while bits_count != 0 {
-      symbol =
-        fast!((symbol_lists)[(symbol_lists_offset as isize + symbol as isize) as usize]) as i32;
+      symbol = match symbol_list_value(symbol_lists, symbol_lists_offset, symbol) {
+        Some(symbol) => symbol as i32,
+        None => return 0,
+      };
       code.value = symbol as u16;
-      ReplicateValue(&mut root_table,
-                     table_free_offset + BrotliReverseBits(key),
-                     step,
-                     table_size,
-                     code);
-      key += key_step;
+      let reversed_key = match BrotliReverseBits(key) {
+        Some(reversed_key) => reversed_key,
+        None => return 0,
+      };
+      let table_offset = match table_free_offset.checked_add(reversed_key) {
+        Some(table_offset) => table_offset,
+        None => return 0,
+      };
+      if !ReplicateValue(&mut root_table, table_offset, step, table_size, code) {
+        return 0;
+      }
+      key = match key.checked_add(key_step) {
+        Some(key) => key,
+        None => return 0,
+      };
       bits_count -= 1;
     }
     step <<= 1;
@@ -335,12 +442,32 @@ pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
   // if root_bits != table_bits we only created one fraction of the
   // table, and we need to replicate it now.
   while total_size != table_size {
-    for index in 0..table_size {
-      // FIXME: did I get this right?
-      fast_mut!((root_table)[table_free_offset as usize + table_size as usize + index as usize]) =
-        fast!((root_table)[table_free_offset as usize + index as usize]);
+    if table_size <= 0 || table_size > total_size {
+      return 0;
     }
-    table_size <<= 1;
+    for index in 0..table_size {
+      let source_index = match (table_free_offset as usize).checked_add(index as usize) {
+        Some(source_index) => source_index,
+        None => return 0,
+      };
+      let destination_index =
+        match source_index.checked_add(table_size as usize) {
+          Some(destination_index) => destination_index,
+          None => return 0,
+        };
+      let value = match root_table.get(source_index) {
+        Some(value) => *value,
+        None => return 0,
+      };
+      match root_table.get_mut(destination_index) {
+        Some(destination) => *destination = value,
+        None => return 0,
+      }
+    }
+    table_size = match table_size.checked_shl(1) {
+      Some(table_size) => table_size,
+      None => return 0,
+    };
   }
 
   // fill in 2nd level tables and add pointers to root table
@@ -355,30 +482,74 @@ pub fn BrotliBuildHuffmanTable(mut root_table: &mut [HuffmanCode],
     let mut symbol: i32 = len - (BROTLI_HUFFMAN_MAX_CODE_LENGTH as i32 + 1);
     while fast!((count)[len as usize]) != 0 {
       if sub_key == (BROTLI_REVERSE_BITS_LOWEST << 1u32) {
-        table_free_offset += table_size as u32;
-        table_bits = NextTableBitSize(count, len, root_bits);
-        table_size = 1 << table_bits;
-        total_size += table_size;
-        sub_key = BrotliReverseBits(key);
-        key += key_step;
-        fast_mut!((root_table)[sub_key as usize]).bits = (table_bits + root_bits) as u8;
-        fast_mut!((root_table)[sub_key as usize]).value =
-          ((table_free_offset as usize) - sub_key as usize) as u16;
+        table_free_offset = match table_free_offset.checked_add(table_size as u32) {
+          Some(table_free_offset) => table_free_offset,
+          None => return 0,
+        };
+        table_bits = match NextTableBitSize(count, len, root_bits) {
+          Some(table_bits) => table_bits,
+          None => return 0,
+        };
+        table_size = match 1i32.checked_shl(table_bits as u32) {
+          Some(table_size) => table_size,
+          None => return 0,
+        };
+        total_size = match total_size.checked_add(table_size) {
+          Some(total_size) => total_size,
+          None => return 0,
+        };
+        sub_key = match BrotliReverseBits(key) {
+          Some(sub_key) => sub_key,
+          None => return 0,
+        };
+        key = match key.checked_add(key_step) {
+          Some(key) => key,
+          None => return 0,
+        };
+        let table_value =
+          match (table_free_offset as usize).checked_sub(sub_key as usize) {
+            Some(table_value) if table_value <= u16::MAX as usize => table_value as u16,
+            _ => return 0,
+          };
+        match root_table.get_mut(sub_key as usize) {
+          Some(entry) => {
+            entry.bits = (table_bits + root_bits) as u8;
+            entry.value = table_value;
+          },
+          None => return 0,
+        }
         sub_key = 0;
       }
       code.bits = (len - root_bits) as u8;
-      symbol =
-        fast!((symbol_lists)[(symbol_lists_offset as isize + symbol as isize) as usize]) as i32;
+      symbol = match symbol_list_value(symbol_lists, symbol_lists_offset, symbol) {
+        Some(symbol) => symbol as i32,
+        None => return 0,
+      };
       code.value = symbol as u16;
-      ReplicateValue(&mut root_table,
-                     table_free_offset + BrotliReverseBits(sub_key),
-                     step,
-                     table_size,
-                     code);
-      sub_key += sub_key_step;
-      fast_mut!((count)[len as usize]) -= 1;
+      let reversed_sub_key = match BrotliReverseBits(sub_key) {
+        Some(reversed_sub_key) => reversed_sub_key,
+        None => return 0,
+      };
+      let table_offset = match table_free_offset.checked_add(reversed_sub_key) {
+        Some(table_offset) => table_offset,
+        None => return 0,
+      };
+      if !ReplicateValue(&mut root_table, table_offset, step, table_size, code) {
+        return 0;
+      }
+      sub_key = match sub_key.checked_add(sub_key_step) {
+        Some(sub_key) => sub_key,
+        None => return 0,
+      };
+      match count.get_mut(len as usize) {
+        Some(count_value) if *count_value != 0 => *count_value -= 1,
+        _ => return 0,
+      }
     }
-    step <<= 1;
+    step = match step.checked_shl(1) {
+      Some(step) => step,
+      None => return 0,
+    };
     sub_key_step >>= 1;
     len += 1
   }
@@ -392,9 +563,27 @@ pub fn BrotliBuildSimpleHuffmanTable(table: &mut [HuffmanCode],
                                      val: &[u16],
                                      num_symbols: u32)
                                      -> u32 {
+  if root_bits <= 0 || root_bits >= 32 || num_symbols > 4 {
+    return 0;
+  }
+  let required_symbols = match num_symbols {
+    0 => 1,
+    1 => 2,
+    2 | 3 => 3,
+    4 => 4,
+    _ => return 0,
+  };
+  if val.len() < required_symbols {
+    return 0;
+  }
   let mut table_size: u32 = 1;
-  let goal_size: u32 = 1u32 << root_bits;
-  assert!(num_symbols <= 4);
+  let goal_size = match 1u32.checked_shl(root_bits as u32) {
+    Some(goal_size) => goal_size,
+    None => return 0,
+  };
+  if table.len() < goal_size as usize {
+    return 0;
+  }
   if num_symbols == 0 {
     fast_mut!((table)[0]).bits = 0;
     fast_mut!((table)[0]).value = fast!((val)[0]);
@@ -459,7 +648,7 @@ pub fn BrotliBuildSimpleHuffmanTable(table: &mut [HuffmanCode],
     fast_mut!((table)[7]).bits = 3;
     table_size = 8;
   } else {
-    assert!(false);
+    return 0;
   }
   while table_size != goal_size {
     for index in 0..table_size {

--- a/src/huffman/tests.rs
+++ b/src/huffman/tests.rs
@@ -1,6 +1,23 @@
 #[cfg(test)]
 
 use super::*;
+
+#[test]
+fn invalid_huffman_inputs_return_errors() {
+  let mut table = [HuffmanCode::default(); 8];
+  let values = [0u16; 4];
+  assert_eq!(BrotliBuildSimpleHuffmanTable(&mut table, 3, &values, 5), 0);
+  assert_eq!(BrotliBuildSimpleHuffmanTable(&mut table[..4], 3, &values, 4), 0);
+
+  let code_lengths = [0u8; 18];
+  let count = [0u16; 6];
+  assert!(!BrotliBuildCodeLengthsHuffmanTable(
+    &mut table,
+    &code_lengths,
+    &count,
+  ));
+}
+
 #[test]
 fn code_length_ht() {
   let code_lengths: [u8; 19] = [0, 2, 3, 0, 2, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];

--- a/src/test.rs
+++ b/src/test.rs
@@ -116,6 +116,46 @@ fn test_block_len_trees_allocation_failure() {
   }
 }
 
+#[test]
+fn test_rejects_invalid_carry_buffer_length() {
+  let input = [];
+  let mut output = [];
+  let mut stack_u8_buffer = define_allocator_memory_pool!(4096, u8, [0; 16 * 1024], stack);
+  let mut stack_u32_buffer = define_allocator_memory_pool!(4096, u32, [0; 4 * 1024], stack);
+  let mut stack_hc_buffer = define_allocator_memory_pool!(4096,
+                                                          HuffmanCode,
+                                                          [HuffmanCode::default(); 20 * 1024],
+                                                          stack);
+  let stack_u8_allocator = MemPool::<u8>::new_allocator(&mut stack_u8_buffer, bzero);
+  let stack_u32_allocator = MemPool::<u32>::new_allocator(&mut stack_u32_buffer, bzero);
+  let stack_hc_allocator = MemPool::<HuffmanCode>::new_allocator(&mut stack_hc_buffer, bzero);
+  let mut state = BrotliState::new(stack_u8_allocator, stack_u32_allocator, stack_hc_allocator);
+  state.buffer_length = state.buffer.len() as u32 + 1;
+  let mut available_in = 0;
+  let mut input_offset = 0;
+  let mut available_out = 0;
+  let mut output_offset = 0;
+  let mut total_out = 0;
+
+  let result = BrotliDecompressStream(&mut available_in,
+                                      &mut input_offset,
+                                      &input,
+                                      &mut available_out,
+                                      &mut output_offset,
+                                      &mut output,
+                                      &mut total_out,
+                                      &mut state);
+
+  match result {
+    BrotliResult::ResultFailure => {}
+    _ => panic!("invalid carry-buffer length must fail decoding"),
+  }
+  match state.error_code {
+    super::state::BrotliDecoderErrorCode::BROTLI_DECODER_ERROR_UNREACHABLE => {}
+    _ => panic!("unexpected decoder error for invalid carry-buffer length"),
+  }
+}
+
 // no-std variant of oneshot that seeds the decoder with a custom dictionary.
 fn oneshot_dict(input: &mut [u8], dict: &[u8], mut output: &mut [u8]) -> (BrotliResult, usize, usize) {
   let mut available_out: usize = output.len();


### PR DESCRIPTION
Malformed or truncated Brotli streams can reach unchecked arithmetic, asserts, indexing, bit-reader, Huffman-table, and buffer-copy paths.
These failures may panic in normal builds and terminate the entire process when compiled with `panic=abort` such as Chromium.

Unsafe builds can also violate pointer-copy preconditions.
Now all the asserts are removed from the decoder.